### PR TITLE
Menu to re-watch Adventure Mode Cutscenes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /graphics/inlevel/reserve/*
 /graphics/menu/reserve/*
 /graphics/menu/dumps/*.bin
+/graphics/__pycache__/*
+/graphics/minigamesplashes/__pycache__/*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-This is my translation project of the game Kururin Paradise. Check out the wiki and assorted assembly files in this repository for some documentation on the ROM.
+This is my English translation project of the game Kururin Paradise. Check out the wiki and assorted assembly files in this repository for some documentation on the ROM.
+
+## Extra Features
+In addition to the translation aspect of this project, there is some additional functionality:
+* You can re-watch Adventure Mode cutscenes in Practice Mode.
 
 ## Screenshots
 

--- a/asm/customcode.asm
+++ b/asm/customcode.asm
@@ -711,14 +711,26 @@ PracticeStateRepoint:
             add r1, 0xa0
             ldrb r0, [r1]
             cmp r0, 0x00
-            beq @@PlayLastBaron
+            beq @@LastBaron
             cmp r0, 0x01
             beq @@PlayLastBaronAllMagic
             b @@PlayNeoLand
             
-            @@PlayLastBaron:
+            @@LastBaron:
+            mov r2, r1
+            ldr r1, =0x030005A0
+            add r1, 0x90
+            ldr r0, [r1]
+            add r0, 0x0e
+            ldrh r0, [r0]
+            ldr r1, =0xFFF
+            and r0, r1
+            cmp r0, r1
+            bne @@PlayLastBaron
             mov r0, 0x01
-            strb r0, [r1]
+            mov r1, r2
+            strb r0, [r1]  ;the increment that lets you re-watch pre-neo land cutscenes
+            @@PlayLastBaron:
             mov r0, r4
             b @@ExecuteScript
             @@PlayLastBaronAllMagic:

--- a/asm/customcode.asm
+++ b/asm/customcode.asm
@@ -634,9 +634,10 @@ PracticeStateRepoint:
             lsl r3, r0, 0x02 ; r3 now contains 00 or 04
             mov r2, r7
             sub r2, 0x2a
-            ldr r1, =0x03000630
+            ldr r1, =0x030005a0
+            add r1, 0x90 ;630 save file data pointer
             ldr r0, [r1]
-            ldr r1, =0x1df
+            ldr r1, =0x1df ; some lookup to decide cutscenes
             add r0, r0, r1
             add r0, r0, r2
             ldrb r0, [r0, 0x00]
@@ -651,7 +652,8 @@ PracticeStateRepoint:
             lsl r3, r0, 0x02
             mov r2, r7
             sub r2, 0x2a
-            ldr r1, =0x03000630
+            ldr r1, =0x030005a0
+            add r1, 0x90
             ldr r0, [r1]
             ldr r1, =0x1df
             add r0, r0, r1
@@ -662,6 +664,26 @@ PracticeStateRepoint:
             ldr r1, =LoseWinArray
             add r1, r1, r0
             ldr r0, [r1, 0x00]
+            mov r4, r0
+            ; extra logic to write the minigame/magic unlocked
+            ldr r1, =0x0802e514
+            mov r0, r7
+            mov r2, r0
+            sub r2, 0x2a
+            add r0, r2, r1
+            ldrb r0, [r0, 0x00] ; proper minigame id
+            sub r0, r0, 0x01
+            ldr r1, =0x030005a0
+            add r1, 0x95
+            mov r3, r1
+            strb r0, [r1, 0x00] ; store minigame unlocked
+            ldr r1, =0x0802ea90
+            add r0, r2, r1
+            ldrb r0, [r0, 0x00]
+            mov r1, r3
+            strb r0, [r1, 0x01]
+            
+            mov r0, r4
             @@ExecuteScript:
             mov r1, 0x08
             mov r2, 0x01

--- a/asm/customcode.asm
+++ b/asm/customcode.asm
@@ -484,7 +484,45 @@ RelOffsetToWidth:
 	bx r14
 	.pool
     .align
-        
+    
+InitPracticeCutsceneMenu:
+    ; basically just copy 08014728 (open up in No$gba to avoid stack errors...)
+    ; TODO - not allow menu selection if magic hat isn't beaten yet
+    mov r0, 0x34
+    bl 0x0803cf44 ; sfx
+    
+    ldr r0, =RenderPracticeCutsceneMenu
+    str r0, [sp, 0x08]
+    mov r1, sp
+    mov r0, 0x04 ; know the max size of menu
+    strb r0, [r1]
+    mov r0, sp
+    strb r6, [r0, 0x01] ; r6 = 0x01 (default selection)
+    mov r5, sp
+    ; retrieve coords of level id
+    ldr r2, =0x0802E28C ; OW x coords
+    lsl r3, r7, 0x02 ; r7 contains level id
+    add r0, r3, r2
+    ldrb r1, [r0] ; raw x-coord
+    ldr r4, =0x030053A0
+    ldr r0, [r4, 0x10]
+    add r0, 0x10
+    sub r1, r1, r0
+    strb r1, [r5, 0x02] ; store x-coord
+    add r2, 0x02 ; y coords are offset
+    add r3, r3, r2
+    ldrb r1, [r3]
+    ldr r0, [r4, 0x14]
+    sub r0, 0x10
+    sub r1, r1, r0
+    strb r1, [r5, 0x03] ; store y-coord
+    mov r6, 0x03 ; !! custom state
+    bx r14
+    .pool
+    .align
+
+RenderPracticeCutsceneMenu:
+
 .ifdef __DEBUG__
     ResetRankHook:
     ldr r0, =0x030005E9

--- a/asm/customcode.asm
+++ b/asm/customcode.asm
@@ -510,6 +510,7 @@ InitPracticeCutsceneMenu:
     @@MinigameBeaten:
     mov r0, 0x34
     bl 0x0803CF44 ; sfx
+    
     ldr r0, =RenderPracticeCutsceneMenu+1
     str r0, [sp, 0x10]
     mov r1, sp
@@ -662,7 +663,7 @@ PracticeStateRepoint:
             add r0, r0, r3
             ldr r1, =StartRetryArray
             add r1, r1, r0
-            ldr r0, [r1, 0x00]
+            ldr r0, [r1, 0x00] ; get script
             b @@ExecuteScript
             @@LoseWin:
             lsr r0, r3, 0x02 ; 00 = lose, 04 = win
@@ -701,12 +702,49 @@ PracticeStateRepoint:
             strb r0, [r1, 0x01]
             
             mov r0, r4
+            ldr r1, =Baron3Win
+            ldr r1, [r1]
+            sub r0, r0, r1
+            cmp r0, 0x00
+            bne @@NotBaron3
+            ldr r1, =0x030005a0
+            add r1, 0xa0
+            ldrb r0, [r1]
+            cmp r0, 0x00
+            beq @@PlayLastBaron
+            cmp r0, 0x01
+            beq @@PlayLastBaronAllMagic
+            b @@PlayNeoLand
+            
+            @@PlayLastBaron:
+            mov r0, 0x01
+            strb r0, [r1]
+            mov r0, r4
+            b @@ExecuteScript
+            @@PlayLastBaronAllMagic:
+            mov r0, 0x02
+            strb r0, [r1]
+            ldr r0, =LastBaronWin
+            ldr r0, [r0]
+            b @@ExecuteScript
+            @@PlayNeoLand:
+            mov r0, 0x00
+            strb r0, [r1]
+            mov r0, 0x18
+            bl 0x0800A1B8
+            ldr r0, =NeoLandCutscene
+            ldr r0, [r0]
+            b @@ExecuteScript
+            
+            @@NotBaron3:
+            mov r0, r4
             @@ExecuteScript:
             mov r1, 0x08
             mov r2, 0x01
             mov r3, 0x04
             bl 0x08014324 ; execute script
             
+            @@Cleanup:
             ; post-script cleanup - reset the practice world state
             mov r0, 0x00
             ldr r1, =0x030005a0

--- a/asm/customcode.asm
+++ b/asm/customcode.asm
@@ -575,13 +575,23 @@ PracticeStateRepoint:
         mov r6, 0x01
         b @@DefaultBranch
         .pool
+        .align
         
         @@NoBPress:
         mov r0, 0x09
         and r0, r1
         cmp r0, 0x00
         beq @@DefaultBranch
-        ; on A/start press, add implementation here!!
+        ; on A/start press, add implementation here!! (reality: check if ctrl flag 0x04 bit is set below, this delays the cutscene trigger until after the transition is finished)
+        
+        ; r7 contains level id
+        ldr r0, =0x030005a0
+        add r0, 0x90
+        ldr r2, [r0, 0x00]
+        ldr r0, =0x1F3
+        add r0, r2, r0
+        mov r1, r7
+        strb r1, [r0, 0x00] ; store current level id in SRAM
         
         ldr r0, =0x08001C25
         mov r1, 0x08

--- a/asm/customcode.asm
+++ b/asm/customcode.asm
@@ -489,16 +489,18 @@ InitPracticeCutsceneMenu:
     ; basically just copy 08014728 (open up in No$gba to avoid stack errors...)
     ; TODO - not allow menu selection if magic hat isn't beaten yet
     push r14
+    sub sp, 0x04
+    
     mov r0, 0x34
     bl 0x0803CF44 ; sfx
     
-    ldr r0, =RenderPracticeCutsceneMenu
-    str r0, [sp, 0x08]
+    ldr r0, =RenderPracticeCutsceneMenu+1
+    str r0, [sp, 0x10]
     mov r1, sp
     mov r0, 0x04 ; know the max size of menu
-    strb r0, [r1]
+    strb r0, [r1, 0x08]
     mov r0, sp
-    strb r6, [r0, 0x01] ; r6 = 0x01 (default selection happens to be sub-state)
+    strb r6, [r0, 0x09] ; r6 = 0x01 (default selection happens to be sub-state)
     mov r5, sp
     ; retrieve coords of level id
     ldr r2, =0x0802E28C ; OW x coords
@@ -509,15 +511,17 @@ InitPracticeCutsceneMenu:
     ldr r0, [r4, 0x10]
     add r0, 0x10
     sub r1, r1, r0
-    strb r1, [r5, 0x02] ; store x-coord
+    strb r1, [r5, 0x0a] ; store x-coord
     add r2, 0x02 ; y coords are offset
     add r3, r3, r2
     ldrb r1, [r3]
     ldr r0, [r4, 0x14]
     sub r0, 0x10
     sub r1, r1, r0
-    strb r1, [r5, 0x03] ; store y-coord
+    strb r1, [r5, 0x0b] ; store y-coord
     mov r6, 0x03 ; !! custom state
+    
+    add sp, 0x04
     pop r0
     bx r0
     .pool
@@ -561,7 +565,7 @@ PracticeStateRepoint:
         add r0, r4, 0x00
         add r0, 0x4c
         ldrh r1, [r0, 0x00] ; key press mask
-        add r0, r0, 0x02
+        mov r0, 0x02
         and r0, r1
         cmp r0, 0x00
         beq @@NoBPress
@@ -581,7 +585,8 @@ PracticeStateRepoint:
         
         ldr r0, =0x08001C25
         mov r1, 0x08
-        bl 0x080944AC ; resume execution on "default branch"
+        bl 0x080944AC ; fadeout object
+        ; resume execution on "default branch"
         
     @@DefaultBranch:
     ldr r4, =0x030005A0
@@ -593,8 +598,7 @@ PracticeStateRepoint:
     and r0, r1
     cmp r0, r0
     beq @@DontExit
-    mov r6, 0x01
-    rsb r6, r6 ; this exits practice mode, I think
+    mov r6, -0x01; this exits practice mode, I think
     @@DontExit:
     add r0, r7, 0x00
     bl 0x08014020 ; draw OW Sidebar and Map
@@ -602,16 +606,22 @@ PracticeStateRepoint:
     add r0, 0x4c
     ldrh r1, [r0, 0x00]
     mov r0, sp
+    add r0, r0, 0x04
     mov r2, 0x33
     bl 0x080945BC ; menu scroll listen
     bl 0x08094530 ; update objects?
     bl 0x08092754 ; prep DMA of object tiles
-    bl 0x0809221c ; update OAM mirror?
+    bl 0x0809221C ; update OAM mirror?
     
     b @@Exit
     
 RenderPracticeCutsceneMenu:
     ;TODO - parse ASCII + textbox for cutscene menu
+    push r14
+    
+    mov r0, 0x00
+    pop r1
+    bx r1
     
 .ifdef __DEBUG__
     ResetRankHook:

--- a/asm/customcode.asm
+++ b/asm/customcode.asm
@@ -490,10 +490,26 @@ InitPracticeCutsceneMenu:
     ; TODO - not allow menu selection if magic hat isn't beaten yet
     push r14
     sub sp, 0x04
+    ; logic to check cleared here
+    ldr r1, =0x030005a0
+    add r1, 0x90
+    ldr r0, [r1] ; current SRAM ptr
+    mov r1, 0xc2
+    lsl r1, r1, 0x01
+    add r0, r0, r1
+    add r0, r0, r7 ;get byte corresponding to minigame status
+    ldrb r0, [r0]
+    lsl r0, r0, 0x18
+    asr r0, r0, 0x18
+    cmp r0, 0x01
+    bgt @@MinigameBeaten
+    mov r0, 0x50
+    bl 0x0803CF44
+    b @InitEnd
     
+    @@MinigameBeaten:
     mov r0, 0x34
     bl 0x0803CF44 ; sfx
-    
     ldr r0, =RenderPracticeCutsceneMenu+1
     str r0, [sp, 0x10]
     mov r1, sp
@@ -521,6 +537,7 @@ InitPracticeCutsceneMenu:
     strb r1, [r5, 0x0b] ; store y-coord
     mov r6, 0x03 ; !! custom state
     
+    @InitEnd:
     add sp, 0x04
     pop r0
     bx r0
@@ -692,6 +709,10 @@ PracticeStateRepoint:
             
             ; post-script cleanup - reset the practice world state
             mov r0, 0x00
+            ldr r1, =0x030005a0
+            add r1, 0x95
+            strb r0, [r1, 0x00] ;zero out unlocked minigame/magic
+            strb r0, [r1, 0x01] ;zero out unlocked minigame/magic
             mov r6, r0
     
     @@Continue:

--- a/asm/customcode.asm
+++ b/asm/customcode.asm
@@ -638,16 +638,236 @@ RenderPracticeCutsceneMenu:
     @@Param2UB:
     ldr r0, =0x101
     cmp r1, r0
-    bge @@IsText
+    bge @IsTextJump
         @@Fallthrough:
         ; r1 is less than 0x101 here
         ; skip other checks (<1, <5)
         cmp r1, r2
-        beq @@FuncEnd ; not implemented yet
-        b @@FuncEnd
+        beq @@DrawBox
+        b @FuncEnd
     .pool
     .align
-    @@IsText: ; 0x101 to 0x104 here (r1)
+    @@DrawBox:
+        bl 0x080923DC ; something with free rotation param indices
+        add r5, r0, 0x00
+        cmp r5, 0x00
+        bge @DrawBoxMain
+        b @FixCoords
+    @IsTextJump:
+        b @IsText
+    @DrawBoxMain:
+        mov r0, 0x00
+        str r0, [sp]
+        mov r0, r5
+        mov r1, 0x00
+        mov r2, 0x00
+        mov r3, 0x00
+        bl 0x080923FC ; idk, it's all boilerplate to me
+        ; want the size 4 case for drawing the box - that's at 0x08014960
+        mov r0, 0x02
+        bl 0x080922D4
+        mov r3, r0
+        cmp r3, 0x00
+        beq @@NullObj1
+        lsl r2, r5, 0x19
+        mov r1, 0x04
+        ldsh r0, [r4, r1]
+        sub r0, 0x04
+        lsl r0, r0, 0x10
+        ldr r1, =0x1FF0000
+        and r0, r1
+        ldr r1, =0x40004500
+        orr r0, r1
+        orr r2, r0
+        str r2, [r3]
+        ldr r2, =0xF3FE
+        mov r0, r2
+        strh r0, [r3, 0x04]
+        ldrb r0, [r4, 0x06]
+        add r0, 0x1c
+        strb r0, [r3]
+        
+        @@NullObj1:
+        mov r0, 0x02
+        bl 0x080922D4
+        mov r2, r0
+        cmp r2, 0x00
+        beq @@NullObj2
+        mov r1, 0x04
+        ldsh r0, [r4, r1]
+        add r0, 0x1C
+        lsl r0, r0, 0x10
+        ldr r1, =0x1FF0000
+        and r0, r1
+        mov r1, 0x80
+        lsl r1, r1, 0x03
+        orr r0, r1
+        str r0, [r2]
+        mov r1, 0xF0
+        lsl r1, r1, 0x08
+        mov r0, r1
+        strh r0, [r2, 0x04]
+        ldrb r0, [r4, 0x06]
+        add r0, 0x1c
+        strb r0, [r2]
+        
+        @@NullObj2:
+        mov r0, 0x02
+        bl 0x080922D4 ; bookkeeping - we're at 0x080149be
+        add r3, r0, 0x00
+        cmp r3, 0x00
+        beq @@NullObj3
+        lsl r2, r5, 0x19
+        mov r1, 0x04
+        ldsh r0, [r4, r1]
+        sub r0, 0x04
+        lsl r0, r0, 0x10
+        ldr r1, =0x1FF0000
+        and r0, r1
+        ldr r1, =0x40004500
+        orr r0, r1
+        orr r2, r0
+        str r2, [r3]
+        ldr r2, =0xF3FE
+        mov r0, r2
+        strh r0, [r3, 0x04]
+        ldrb r0, [r4, 0x06]
+        add r0, 0x14 ; same as the part after beq @@NullObj1, except 0x1c replaced with 0x14
+        strb r0, [r3]
+        
+        @@NullObj3:
+        mov r0, 0x02
+        bl 0x080922D4
+        mov r2, r0
+        cmp r2, 0x00
+        beq @@NullObj4
+        mov r1, 0x04
+        ldsh r0, [r4, r1]
+        add r0, 0x1C
+        lsl r0, r0, 0x10
+        ldr r1, =0x1FF0000
+        and r0, r1
+        mov r1, 0x80
+        lsl r1, r1, 0x03
+        orr r0, r1
+        str r0, [r2]
+        mov r1, 0xF0
+        lsl r1, r1, 0x08
+        mov r0, r1
+        strh r0, [r2, 0x04]
+        ldrb r0, [r4, 0x06]
+        add r0, 0x14
+        strb r0, [r2]
+        
+        @@NullObj4:
+        mov r0, 0x02
+        bl 0x080922D4 ; 0x08014a1a
+        add r3, r0, 0x00
+        cmp r3, 0x00
+        beq @@NullObj5
+        lsl r2, r5, 0x19
+        mov r1, 0x04
+        ldsh r0, [r4, r1]
+        sub r0, 0x04
+        lsl r0, r0, 0x10
+        ldr r1, =0x1FF0000
+        and r0, r1
+        ldr r1, =0x40004500
+        orr r0, r1
+        orr r2, r0
+        str r2, [r3]
+        ldr r2, =0xF3FE
+        mov r0, r2
+        strh r0, [r3, 0x04]
+        ldrb r0, [r4, 0x06]
+        add r0, 0xC ; same as the part after beq @@NullObj1, except 0x1c replaced with 0x0c
+        strb r0, [r3]
+        
+        @@NullObj5:
+        mov r0, 0x02
+        bl 0x080922D4
+        mov r2, r0
+        cmp r2, 0x00
+        beq @@NullObj6
+        mov r1, 0x04
+        ldsh r0, [r4, r1]
+        add r0, 0x1C
+        lsl r0, r0, 0x10
+        ldr r1, =0x1FF0000
+        and r0, r1
+        mov r1, 0x80
+        lsl r1, r1, 0x03
+        orr r0, r1
+        str r0, [r2]
+        mov r1, 0xF0
+        lsl r1, r1, 0x08
+        mov r0, r1
+        strh r0, [r2, 0x04]
+        ldrb r0, [r4, 0x06]
+        add r0, 0x0C
+        strb r0, [r2]
+        
+        @@NullObj6:
+        mov r0, 0x02
+        bl 0x080922D4 ; 08014a76
+        add r3, r0, 0x00
+        cmp r3, 0x00
+        beq @@NullObj7
+        lsl r2, r5, 0x19
+        mov r1, 0x04
+        ldsh r0, [r4, r1]
+        sub r0, 0x04
+        lsl r0, r0, 0x10
+        ldr r1, =0x1FF0000
+        and r0, r1
+        ldr r1, =0x80004500
+        orr r0, r1
+        orr r2, r0
+        str r2, [r3]
+        ldr r2, =0xF3FE
+        mov r0, r2
+        strh r0, [r3, 0x04]
+        ldrb r0, [r4, 0x06]
+        sub r0, 0x04 ; same as the part after beq @@NullObj1, except 0x1c replaced with 0x04
+        strb r0, [r3, 0x00]
+        
+        @@NullObj7:
+        mov r0, 0x02
+        bl 0x080922D4 ;08014aa4
+        mov r2, r0
+        cmp r2, 0x00
+        beq @FixCoords
+        lsl r2, r5, 0x19
+        mov r1, 0x04
+        ldrsh r0, [r4, r1] ; x-coord
+        add r0, 0x1c
+        lsl r0, r0, 0x10
+        ldr r1, =0x1FF0000
+        and r0, r1
+        mov r1, 0x85
+        lsl r1, r1, 0x08
+        orr r0, r1
+        orr r2, r0
+        str r2, [r3, 0x00]
+        ldr r2, =0xF3FF
+        add r0, r2, 0x00
+        strh r0, [r3, 0x04]
+        ldrb r0, [r4, 0x06] ; y-coord
+        sub r0, 0x04
+        strb r0, [r3, 0x00]
+        
+    @FixCoords:
+        mov r0, 0x00
+        ldrsb r0, [r4, r0]
+        lsr r1, r0, 0x1f
+        add r0, r0, r1
+        asr r0, r0, 0x01 ; dividing by 2
+        ldrh r1, [r4, 0x06]
+        sub r1, r1, r0
+        strh r1, [r4, 0x06]
+        b @FuncEnd
+        
+    @IsText: ; 0x101 to 0x104 here (r1)
     sub r1, r1, r0 ; r1 now contains array index
     ldr r0, =PracticeCutsceneMenuOptions
     lsl r1, r1, 3
@@ -663,7 +883,7 @@ RenderPracticeCutsceneMenu:
     add r0, 0x09 ; line spacing
     strh r0, [r4, 0x06]
     
-    @@FuncEnd:
+    @FuncEnd:
     mov r0, 0x00
     add sp, 0x04
     pop {r4, r5}

--- a/asm/customcode.asm
+++ b/asm/customcode.asm
@@ -583,16 +583,37 @@ PracticeStateRepoint:
         beq @@DefaultBranch
         ; on A/start press, add implementation here!!
         
-        
-        
         ldr r0, =0x08001C25
         mov r1, 0x08
         bl 0x080944AC ; fadeout object
-        ; consult 0x08013290 for executing script (ex: kururin house), or 0x08013228 Neo Land Intermission
-        ; or maybe execute script after making fadeout object?
-        ; resume execution on "default branch"
         
     @@DefaultBranch:
+        ldr r2, =0x030005a0
+        mov r1, 0x84
+        lsl r1, r1, 0x01
+        add r0, r2, r1
+        ldr r1, [r0, 0x00]
+        mov r0, 0x04
+        and r1, r0
+        cmp r1, 0x00
+        bne @@TimeToLoadScript
+        b @@Continue
+        
+            @@TimeToLoadScript:
+            mov r0, 0x18
+            bl 0x0800A1B8 ; change music
+            ldr r0, =0x0801324C
+            ldr r0, [r0]
+            mov r1, 0x08
+            mov r2, 0x01
+            mov r3, 0x04
+            bl 0x08014324 ; execute script
+            
+            ; post-script cleanup - reset the practice world state
+            mov r0, 0x00
+            mov r6, r0
+    
+    @@Continue:
     ldr r4, =0x030005A0
     mov r1, 0x84
     lsl r1, r1, 0x01

--- a/asm/vwfalpha.asm
+++ b/asm/vwfalpha.asm
@@ -48,5 +48,8 @@
 .org 0x08021120 ;pointer to script parser
 	.word ScriptParse
 
-
+.org 0x08014706 ; practice mode, A button on a magic hat (normally does nothing)
+.area 4h
+    bl InitPracticeCutsceneMenu
+.endarea
 	

--- a/asm/vwfalpha.asm
+++ b/asm/vwfalpha.asm
@@ -53,3 +53,7 @@
     bl InitPracticeCutsceneMenu
 .endarea
 	
+.org 0x080145da ; practice mode state check
+.area 4h
+    bl PracticeStateRepoint
+.endarea

--- a/text/insertscripts.asm
+++ b/text/insertscripts.asm
@@ -7,6 +7,7 @@
 	.word @NewEndingScript
 
 .org 0x0802E4B4 ;repointing cutscene script locations
+    StartRetryArray:
 	.word @Kappado1start
 	.word @Kappado1redo
 	.word @Kappado2start
@@ -33,6 +34,7 @@
 	.word @Baron3redo
 
 .org 0x0802EA9C
+    LoseWinArray:
 	.word @Kappado1lose
 	.word @Kappado1win
 	.word @Kappado2lose

--- a/text/insertscripts.asm
+++ b/text/insertscripts.asm
@@ -58,6 +58,7 @@
 	.word @Baron2lose
 	.word @Baron2win
 	.word @Baron3lose
+    Baron3Win:
 	.word @Baron3win
     
 .org 0x080292DC
@@ -80,9 +81,11 @@
 	.word script_loc1
 
 .org 0x0801A38C ;beat Baron Magic's 3rd minigame, and it's the last one 
+    LastBaronWin:
 	.word @Baron3winlast
 
 .org 0x0801324C ;cutscene with Baron Magic before Neo Land
+    NeoLandCutscene:
 	.word @Intermission
 	
 .org 0x08010DF0

--- a/text/menu.asm
+++ b/text/menu.asm
@@ -19,8 +19,8 @@
 
 repointText 0x0802DF70,"Venture many lands and" ;Adventure
 repointText 0x0802DF74,"search for your family!"
-repointText 0x0802DF78,"Practice courses from the" ;Practice
-repointText 0x0802DF7C,"Adventure Mode!"
+repointText 0x0802DF78,"Practice courses and re－watch" ;Practice
+repointText 0x0802DF7C,"cutscenes from Adventure Mode!"
 repointText 0x0802DF80,"Test your skills on" ;Challenge
 repointText 0x0802DF84,"Courses and minigames!"
 repointText 0x0802DF88,"Perform magic using" ;Magic


### PR DESCRIPTION
Testing dialogue edits has been pretty bothersome with no easy way to access each cutscene. The 12 magic hats each have 4 separate cutscenes depending on certain criteria: Entering the first/subsequent times, and losing/winning the minigame. It's inconvenient to have separate save states on hand for each minigame.

As a remedy for this, as well as some QoL, I've implemented a custom menu in Practice Mode that lets you re-watch each cutscene. Normally, selecting a minigame in Practice Mode does nothing, so this only adds extra functionality. This is also a convenient way to prevent players from accessing the cutscenes too early (You must have reached **and** beaten the minigame in Adventure mode to access this menu).

There are additional cutscenes that play when the last Baron Magic minigame is the last one you've beaten, and shortly before entering Neo Land. These can be accessed by selecting the Win option at the 3rd Baron Magic minigame subsequent times.

![menu](https://github.com/Dimedime-d/kptranslation/assets/73413313/6b0f140c-533e-4216-a67b-7ec8f6a14fee)
